### PR TITLE
Populate includes field in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Arduino Library for 4D Systems Serial Environment for Diablo16 based m
 category=Display
 url=https://github.com/4dsystems/Diablo16-Serial-Arduino-Library
 architectures=*
-includes=
+includes=Diablo_Const4D.h,Diablo_Serial_4DLib.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which #include directives should be added to the sketch via Sketch > Include Library > LIBRARYNAME. Leaving this field empty causes that action to add the following line to the sketch:

#include <>

which results in a compilation error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format