### PR TITLE
Issue with defines and other warnings.

### DIFF
--- a/issue.txt
+++ b/issue.txt
@@ -1,0 +1,1 @@
+Issue tracker was disabled, so here's a pull request.


### PR DESCRIPTION
You have issues disabled, and I need input before trying to fix this issue, so I'm starting a pull request and we'll go from there.

Does this library regularly get compiled with warnings enabled? Because there's a LOT of them. Some of them like "unused variable" I can fix and wouldn't mind adding to this diff.

Some defines are fixable. For example, in the upgrade from 1.0.0 to 1.0.1, it seems like the redefines of DEC, BIN, HEX, etc. were removed which is awesome, but there's still a lot of problematic ones there.

The remaining ones that are giving me trouble is that PINK is a color definition, but in Arduino land it's "Pin K". Similarly, you redefine PA0 through PA7 to be different values, and those are supposed to be used as part of the PORTA define set. TIMER2 is the last one that I noticed was redefined from the core Arduino utilities.

My personal preference in this type of situation is to have scoped classes or namespaces with constexpr variables. e.g., you could have a class called "4D_Colors" and "PINK" could be a constexpr variable inside of that. It still must be known at compile time and it's inlined like a define is, but you don't trash other defines.