### PR TITLE
Fixed setbaudWait function

### DIFF
--- a/examples/BigDemo/BigDemo.ino
+++ b/examples/BigDemo/BigDemo.ino
@@ -18,7 +18,7 @@
 /*                                                                                           */
 /*                   Define the serial port to use here, if using software serial set it to  */
 /*                   something like SerialS.                                                 */
-  #define DisplaySerial Serial
+#define DisplaySerial Serial
 /*                                                                                           */
 /*                   To use SoftwareSerial uncomment the following and set the pins you are  */
 /*                   using correctly                                                         */
@@ -34,17 +34,13 @@
 /*                   occurs. If you want to do your own handling set Callback4D to NULL      */
 /*                   otherwise set it to the address of the error routine                    */
 /*                                                                                           */
-/* Baud rate change  Because the stream class used within the library does not support       */
-/*                   .end, or .begin the setbaudWait and SetThisBaudrate functions are       */
-/*                   coded within this demo                                                  */
-/*                                                                                           */
 /* Sketch Size!      If you are logging messages, then you may exceed the maximum sketch     */
 /*                   size for some of the smaller boards, you can comment out TEST_USD to    */
 /*                   exclude tests that require a uSD card to run and/or TEST_OTHER to       */
 /*                   exclude tests that do not require a uSD card to run.                    */
+/*                                                                                           */
 #define TEST_USD
 #define TEST_OTHER
-/*                                                                                           */
 /*                                                                                           */
 /*                   The following files are needed on the uSD to complete all tests. Their  */
 /*                   relative location (from C:\Users\Public\Documents\4D Labs) is shown     */
@@ -67,7 +63,19 @@
 #include "BigDemo.h" 
 #include "Diablo_Const4D.h"
 
+// Use this if using HardwareSerial or SoftwareSerial
 Diablo_Serial_4DLib Display(&DisplaySerial);
+
+// Use this block if using a different Serial class
+//
+// void customSetBaudRate(unsigned long newRate) {
+//   DisplaySerial.flush();
+//   DisplaySerial.end();
+//   DisplaySerial.begin(newRate);
+//   delay(50) ; // Display sleeps for 100
+//   DisplaySerial.flush();  
+// }
+// Diablo_Serial_4DLib Display(&DisplaySerial, customSetBaudRate);
 
 const char *atoz = {"abcdefghijklmnopqrstuvwxyz"} ;
 
@@ -843,69 +851,6 @@ void mycallback(int ErrCode, unsigned char Errorbyte)
 #endif
 }
 
-void SetThisBaudrate(int Newrate)
-{
-  int br ;
-  DisplaySerial.flush() ;
-  DisplaySerial.end() ;
-  switch(Newrate)
-  {
-    case BAUD_110    : br = 110 ;
-      break ;
-    case BAUD_300    : br = 300 ;
-      break ;
-    case BAUD_600    : br = 600 ;
-      break ;
-    case BAUD_1200   : br = 1200 ;
-      break ;
-    case BAUD_2400   : br = 2400 ;
-      break ;
-    case BAUD_4800   : br = 4800 ;
-      break ;
-    case BAUD_9600   : br = 9600 ;
-      break ;
-    case BAUD_14400  : br = 14400 ;
-      break ;
-    case BAUD_19200  : br = 19200 ;
-      break ;
-    case BAUD_31250  : br = 31250 ;
-      break ;
-    case BAUD_38400  : br = 38400 ;
-      break ;
-    case BAUD_56000  : br = 56000 ;
-      break ;
-    case BAUD_57600  : br = 57600 ;
-      break ;
-    case BAUD_115200 : br = 115200 ;
-      break ;
-    case BAUD_128000 : br = 133928 ; // actual rate is not 128000 ;
-      break ;
-    case BAUD_256000 : br = 281250 ; // actual rate is not  256000 ;
-      break ;
-    case BAUD_300000 : br = 312500 ; // actual rate is not  300000 ;
-      break ;
-    case BAUD_375000 : br = 401785 ; // actual rate is not  375000 ;
-      break ;
-    case BAUD_500000 : br = 562500 ; // actual rate is not  500000 ;
-      break ;
-    case BAUD_600000 : br = 703125 ; // actual rate is not  600000 ;
-      break ;
-  }
-  DisplaySerial.begin(br) ;
-  delay(50) ; // Display sleeps for 100
-  DisplaySerial.flush() ;
-}
-
-void setbaudWait(word  Newrate)
-{
-  DisplaySerial.print((char)(F_setbaudWait >> 8));
-  DisplaySerial.print((char)(F_setbaudWait));
-  DisplaySerial.print((char)(Newrate >> 8));
-  DisplaySerial.print((char)(Newrate));
-  SetThisBaudrate(Newrate); // change this systems baud rate to match new display rate, ACK is 100ms away
-  Display.GetAck() ;
-}
-
 #define RESETLINE 4
 
 void setup()
@@ -1078,24 +1023,10 @@ void loop()
     delay(5000) ;
   }
 
-  setbaudWait(BAUD_19200) ;
-  Display.putstr("Hello at 19200\n") ;
-  setbaudWait(BAUD_9600) ;
-  Display.putstr("Back to 9600\n") ;
+  Display.setbaudWait(BAUD_19200);
+  Display.putstr("Hello at 19200\n");
+  Display.setbaudWait(BAUD_9600);
+  Display.putstr("Back to 9600\n");
   delay(5000) ;
 #endif 
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Diablo16-Serial-Arduino-Library
-version=1.0.3
+version=1.0.4
 author=4D Systems
 maintainer=4D Systems
 sentence=Provides library access to communicate with the 4D Systems Diablo16 processor, when configured in Serial/SPE mode

--- a/src/Diablo_Serial_4DLib.cpp
+++ b/src/Diablo_Serial_4DLib.cpp
@@ -11,44 +11,28 @@
 #endif
 
 Diablo_Serial_4DLib::Diablo_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long)) { 
-    _virtualPort = virtualPort; 
-    setBaudRateExternal = setBaudRateHndl;
-    setBaudRateInternal = &Diablo_Serial_4DLib::exSetBaudRateHndl;
-    unknownSerial = true;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = virtualPort; 
+  setBaudRateExternal = setBaudRateHndl;
+  setBaudRateInternal = &Diablo_Serial_4DLib::exSetBaudRateHndl;
+  unknownSerial = true;
 }
 
 Diablo_Serial_4DLib::Diablo_Serial_4DLib(HardwareSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Diablo_Serial_4DLib::hwSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Diablo_Serial_4DLib::hwSetBaudRateHndl;
 }
 
 #ifdef SoftwareSerial_h		
 Diablo_Serial_4DLib::Diablo_Serial_4DLib(SoftwareSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Diablo_Serial_4DLib::swSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Diablo_Serial_4DLib::swSetBaudRateHndl;
 }
 #endif
 
 #ifdef AltSoftSerial_h
 Diablo_Serial_4DLib::Diablo_Serial_4DLib(AltSoftSerial * serial) { 
-    _virtualPort = (Stream *)serial; 
-    setBaudRateInternal = &Diablo_Serial_4DLib::alSetBaudRateHndl;
-#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-	//Only done for non-SAMD/SAM architectures
-	_virtualPort->flush();
-#endif
+  _virtualPort = (Stream *)serial; 
+  setBaudRateInternal = &Diablo_Serial_4DLib::alSetBaudRateHndl;
 }
 #endif
 

--- a/src/Diablo_Serial_4DLib.cpp
+++ b/src/Diablo_Serial_4DLib.cpp
@@ -10,13 +10,47 @@
 	#include "WProgram.h" // for Arduino 23
 #endif
 
-Diablo_Serial_4DLib::Diablo_Serial_4DLib(Stream * virtualPort) { 
+Diablo_Serial_4DLib::Diablo_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long)) { 
     _virtualPort = virtualPort; 
+    setBaudRateExternal = setBaudRateHndl;
+    setBaudRateInternal = &Diablo_Serial_4DLib::exSetBaudRateHndl;
+    unknownSerial = true;
 #if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
 	//Only done for non-SAMD/SAM architectures
 	_virtualPort->flush();
 #endif
 }
+
+Diablo_Serial_4DLib::Diablo_Serial_4DLib(HardwareSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Diablo_Serial_4DLib::hwSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+
+#ifdef SoftwareSerial_h		
+Diablo_Serial_4DLib::Diablo_Serial_4DLib(SoftwareSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Diablo_Serial_4DLib::swSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+#endif
+
+#ifdef AltSoftSerial_h
+Diablo_Serial_4DLib::Diablo_Serial_4DLib(AltSoftSerial * serial) { 
+    _virtualPort = (Stream *)serial; 
+    setBaudRateInternal = &Diablo_Serial_4DLib::alSetBaudRateHndl;
+#if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
+	//Only done for non-SAMD/SAM architectures
+	_virtualPort->flush();
+#endif
+}
+#endif
 
 //*********************************************************************************************//
 //**********************************Intrinsic 4D Routines**************************************//
@@ -215,66 +249,6 @@ word Diablo_Serial_4DLib::GetAckResData(t4DByteArray OutData, word size)
 	Result = GetWord() ;
 	getbytes(OutData, size) ;
 	return Result ;
-}
-
-void Diablo_Serial_4DLib::SetThisBaudrate(int Newrate)
-{
-  int br ;
-  #if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-  //Only done for non-SAMD/SAM architectures
-  _virtualPort->flush() ;
-  #endif
-//  _virtualPort->end() ;
-  switch(Newrate)
-  {
- /*   case BAUD_110    : br = 110 ;
-      break ;
-    case BAUD_300    : br = 300 ;
-      break ;
-    case BAUD_600    : br = 600 ;
-      break ;
-    case BAUD_1200   : br = 1200 ;
-      break ;
-    case BAUD_2400   : br = 2400 ;
-      break ;
-    case BAUD_4800   : br = 4800 ;
-      break ;*/
-    case BAUD_9600   : br = 9600 ;
-      break ;
-//   case BAUD_14400  : br = 14400 ;
-//      break ;
-    case BAUD_19200  : br = 19200 ;
-      break ;
- /*   case BAUD_31250  : br = 31250 ;
-      break ;
-    case BAUD_38400  : br = 38400 ;
-      break ;
-    case BAUD_56000  : br = 56000 ;
-      break ;
-    case BAUD_57600  : br = 57600 ;
-      break ;
-    case BAUD_115200 : br = 115200 ;
-      break ;
-    case BAUD_128000 : br = 133928 ; // actual rate is not 128000 ;
-      break ;
-    case BAUD_256000 : br = 281250 ; // actual rate is not  256000 ;
-      break ;
-    case BAUD_300000 : br = 312500 ; // actual rate is not  300000 ;
-      break ;
-    case BAUD_375000 : br = 401785 ; // actual rate is not  375000 ;
-      break ;
-    case BAUD_500000 : br = 562500 ; // actual rate is not  500000 ;
-      break ;
-    case BAUD_600000 : br = 703125 ; // actual rate is not  600000 ;
-      break ;*/
-  }
-//  _virtualPort->begin(br) ;
-  delay(50) ; // Display sleeps for 100
-  
-  #if !defined(ARDUINO_ARCH_SAMD) || (ARDUINO_ARCH_SAM)
-  //Only done for non-SAMD/SAM architectures
-  _virtualPort->flush() ;
-  #endif
 }
 
 //*********************************************************************************************//
@@ -2016,12 +1990,120 @@ word Diablo_Serial_4DLib::file_FindNextRet(char *  StringIn)
   return GetAckResStr(StringIn) ;
 }
 
-void Diablo_Serial_4DLib::setbaudWait(word  Newrate)
+unsigned long Diablo_Serial_4DLib::GetBaudRate(word Newrate)
 {
+  unsigned long br ;
+  switch(Newrate)
+  {
+    case BAUD_110:
+      br = 110l ;
+      break ;
+    case BAUD_300:
+      br = 300l ;
+      break ;
+    case BAUD_600:
+      br = 600l ;
+      break ;
+    case BAUD_1200:
+      br = 1200l ;
+      break ;
+    case BAUD_2400:
+      br = 2400l ;
+      break ;
+    case BAUD_4800:
+      br = 4800l ;
+      break ;
+    case BAUD_9600:
+      br = 9600l ;
+      break ;
+    case BAUD_14400:
+      br = 14400l ;
+     break ;
+    case BAUD_19200:
+      br = 19200l ;
+      break ;
+    case BAUD_31250:
+      br = 31250l ;
+      break ;
+    case BAUD_38400:
+      br = 38400l ;
+      break ;
+    case BAUD_56000:
+      br = 56000l ;
+      break ;
+    case BAUD_57600:
+      br = 57600l ;
+      break ;
+    case BAUD_115200:
+      br = 115200l ;
+      break ;
+    case BAUD_128000:
+      br = 133928l ; // actual rate is not 128000 ;
+      break ;
+    case BAUD_256000:
+      br = 281250l ; // actual rate is not  256000 ;
+      break ;
+    case BAUD_300000:
+      br = 312500l ; // actual rate is not  300000 ;
+      break ;
+    case BAUD_375000:
+      br = 401785l ; // actual rate is not  375000 ;
+      break ;
+    case BAUD_500000:
+      br = 562500l ; // actual rate is not  500000 ;
+      break ;
+    case BAUD_600000:
+      br = 703125l ; // actual rate is not  600000 ;
+      break ;
+    default:
+      br = 0;
+      break;
+  }
+  return br;
+}
+
+bool Diablo_Serial_4DLib::setbaudWait(word Newrate)
+{
+  if (unknownSerial && (setBaudRateExternal == NULL)) return false;
+  unsigned long baudrate = GetBaudRate(Newrate);
+  if (baudrate == 0) return false;
   _virtualPort->print((char)(F_setbaudWait >> 8));
   _virtualPort->print((char)(F_setbaudWait));
   _virtualPort->print((char)(Newrate >> 8));
   _virtualPort->print((char)(Newrate));
-  SetThisBaudrate(Newrate); // change this systems baud rate to match new display rate, ACK is 100ms away
+  (this->*setBaudRateInternal)(baudrate); // change this systems baud rate to match new display rate, ACK is 100ms away
   GetAck() ;
+  return true;
 }
+
+void Diablo_Serial_4DLib::exSetBaudRateHndl(unsigned long newRate) {
+  setBaudRateExternal(newRate);
+}
+
+void Diablo_Serial_4DLib::hwSetBaudRateHndl(unsigned long newRate) {
+  ((HardwareSerial *)_virtualPort)->flush();
+  ((HardwareSerial *)_virtualPort)->end();
+  ((HardwareSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((HardwareSerial *)_virtualPort)->flush();
+}
+
+#ifdef SoftwareSerial_h
+void Diablo_Serial_4DLib::swSetBaudRateHndl(unsigned long newRate) {
+  ((SoftwareSerial *)_virtualPort)->flush();
+  ((SoftwareSerial *)_virtualPort)->end();
+  ((SoftwareSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((SoftwareSerial *)_virtualPort)->flush();  
+}
+#endif
+
+#ifdef AltSoftSerial_h
+void Diablo_Serial_4DLib::alSetBaudRateHndl(unsigned long newRate) {
+  ((AltSoftSerial *)_virtualPort)->flush();
+  ((AltSoftSerial *)_virtualPort)->end();
+  ((AltSoftSerial *)_virtualPort)->begin(newRate);
+  delay(50) ; // Display sleeps for 100
+  ((AltSoftSerial *)_virtualPort)->flush();  
+}
+#endif		

--- a/src/Diablo_Serial_4DLib.h
+++ b/src/Diablo_Serial_4DLib.h
@@ -16,12 +16,24 @@
 
 #include <string.h>
 
+#ifdef AVR
+#include <SoftwareSerial.h> // uncomment this line to add direct support for SoftwareSerial
+// #include <AltSoftSerial.h> // uncomment this line to add direct support for AltSoftSerial (Note: AltSoftSerial needs to be installed in Arduino IDE)
+#endif
+
 typedef void (*Tcallback4D)(int, unsigned char); 
 
 class Diablo_Serial_4DLib
 {
 	public:
-		Diablo_Serial_4DLib(Stream * virtualPort);
+		Diablo_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long) = NULL);
+		Diablo_Serial_4DLib(HardwareSerial * serial);
+#ifdef SoftwareSerial_h		
+		Diablo_Serial_4DLib(SoftwareSerial * serial);
+#endif
+#ifdef AltSoftSerial_h
+	    Diablo_Serial_4DLib(AltSoftSerial * serial);
+#endif
 		Tcallback4D Callback4D ;
 		
 		//Compound 4D Routines
@@ -193,7 +205,7 @@ class Diablo_Serial_4DLib
 		void blitComtoDisplay(word  X, word  Y, word  Width, word  Height, t4DByteArray  Pixels);
 		word file_FindFirstRet(char *  Filename, char *  StringIn);
 		word file_FindNextRet(char *  StringIn);
-		void setbaudWait(word  Newrate);
+		bool setbaudWait(word Newrate);
 		void GetAck(void);
 		
 		//4D Global Variables Used
@@ -206,7 +218,20 @@ class Diablo_Serial_4DLib
 									// or indeterminate (eg file_exec, file_run, file_callFunction) commands
 		
 	private:
-                Stream * _virtualPort;
+		bool unknownSerial = false;
+		Stream * _virtualPort;
+		unsigned long GetBaudRate(word Newrate);
+		void (*setBaudRateExternal)(unsigned long newRate);
+		void (Diablo_Serial_4DLib::*setBaudRateInternal)(unsigned long newRate);
+
+		void exSetBaudRateHndl(unsigned long newRate);
+		void hwSetBaudRateHndl(unsigned long newRate);
+#ifdef SoftwareSerial_h
+		void swSetBaudRateHndl(unsigned long newRate);
+#endif
+#ifdef AltSoftSerial_h
+		void alSetBaudRateHndl(unsigned long newRate);
+#endif
 
 		//Intrinsic 4D Routines
 		void WriteChars(char * charsout);
@@ -221,10 +246,10 @@ class Diablo_Serial_4DLib
 		word GetAckResSector(t4DSector Sector);
 		word GetAckResStr(char * OutStr);
 		word GetAckResData(t4DByteArray OutData, word size);
-		void SetThisBaudrate(int Newrate);
 		
 		void printNumber(unsigned long, uint8_t);
 		void printFloat(double number, uint8_t digits);
+
 };
  
 #endif


### PR DESCRIPTION
This update adds additional constructors that helps identify what type of Serial is being used. This lets the library correctly perform `end()` and `begin()` for `setbaudWait()`

Changed:
- `Diablo_Serial_4DLib(Stream * virtualPort` to
`Diablo_Serial_4DLib(Stream * virtualPort, void (*setBaudRateHndl)(unsigned long) = NULL)`

Added:
- `Diablo_Serial_4DLib(HardwareSerial * serial);`
- `Diablo_Serial_4DLib(SoftwareSerial * serial);`